### PR TITLE
1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'me.creepermaxcz.mc-bots'
-version '1.2.9'
+version '1.2.10'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -16,7 +16,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.steveice10:mcprotocollib:1.20.2-1'
+    implementation 'com.github.steveice10:mcprotocollib:1.20.4-2-SNAPSHOT'
+    implementation 'net.kyori:adventure-text-serializer-gson:4.16.0'
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'com.diogonunes:JColor:5.2.0'
     implementation 'dnsjava:dnsjava:3.4.3'


### PR DESCRIPTION
updated mcprotocollib to 1.20.4-2-SNAPSHOT
added net.kyori:adventure-text-serializer-gson:4.16.0
as dependency because when building without it it gave error because the version that mcprotcollib used was not available. 

