### PR TITLE
Update for Minecraft 1.21.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.geysermc.mcprotocollib:protocol:1.21.4-SNAPSHOT'
-    implementation 'net.kyori:adventure-text-serializer-gson:4.16.0'
-    implementation 'commons-cli:commons-cli:1.5.0'
-    implementation 'com.diogonunes:JColor:5.2.0'
-    implementation 'dnsjava:dnsjava:3.4.3'
-    implementation 'org.slf4j:slf4j-nop:2.0.13'
-    implementation 'org.jline:jline:3.22.0'
+    implementation 'org.geysermc.mcprotocollib:protocol:1.21.7-SNAPSHOT'
+    implementation 'net.kyori:adventure-text-serializer-gson:4.24.0'
+    implementation 'commons-cli:commons-cli:1.9.0'
+    implementation 'com.diogonunes:JColor:5.5.1'
+    implementation 'dnsjava:dnsjava:3.6.3'
+    implementation 'org.slf4j:slf4j-nop:2.0.17'
+    implementation 'org.jline:jline:3.30.4'
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,6 @@ plugins {
 group 'me.creepermaxcz.mc-bots'
 version '1.2.14'
 
-sourceCompatibility = 1.17
-targetCompatibility = 1.17
-
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -23,6 +20,12 @@ dependencies {
     implementation 'dnsjava:dnsjava:3.4.3'
     implementation 'org.slf4j:slf4j-nop:2.0.13'
     implementation 'org.jline:jline:3.22.0'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 jar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/creepermaxcz/mcbots/Bot.java
+++ b/src/main/java/me/creepermaxcz/mcbots/Bot.java
@@ -165,7 +165,8 @@ public class Bot extends Thread {
                     0L,
                     null,
                     0,
-                    new BitSet()
+                    new BitSet(),
+                    0
             ));
         }
     }


### PR DESCRIPTION
This pull request includes updates to the Gradle wrapper and a minor modification to the `sendChat` method in the `Bot.java` file.

### Build system update:
* Updated the Gradle wrapper to use version 9.0.0 instead of 7.4.2 in `gradle-wrapper.properties`. This ensures compatibility with newer Gradle features and improvements.

### Code modification:
* Modified the `sendChat` method in `Bot.java` to include an additional integer parameter (`0`) in the method call. This likely reflects a change in the method signature or functionality.