### PR TITLE
Update to Minecraft 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'me.creepermaxcz.mc-bots'
-version '1.2.17'
+version '1.2.18'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.geysermc.mcprotocollib:protocol:1.21.7-SNAPSHOT'
+    implementation 'org.geysermc.mcprotocollib:protocol:1.21.11-SNAPSHOT'
     implementation 'net.kyori:adventure-text-serializer-gson:4.24.0'
     implementation 'commons-cli:commons-cli:1.9.0'
     implementation 'com.diogonunes:JColor:5.5.1'
@@ -24,7 +24,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/me/creepermaxcz/mcbots/Main.java
+++ b/src/main/java/me/creepermaxcz/mcbots/Main.java
@@ -2,8 +2,10 @@ package me.creepermaxcz.mcbots;
 
 import net.lenni0451.commons.httpclient.HttpClient;
 import net.raphimc.minecraftauth.MinecraftAuth;
-import net.raphimc.minecraftauth.step.java.session.StepFullJavaSession;
-import net.raphimc.minecraftauth.step.msa.StepMsaDeviceCode;
+import net.raphimc.minecraftauth.java.JavaAuthManager;
+import net.raphimc.minecraftauth.java.model.MinecraftProfile;
+import net.raphimc.minecraftauth.msa.model.MsaDeviceCode;
+import net.raphimc.minecraftauth.msa.service.impl.DeviceCodeMsaAuthService;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
@@ -23,6 +25,7 @@ import java.io.*;
 import java.net.*;
 import java.security.SecureRandom;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 
@@ -277,18 +280,17 @@ public class Main {
             botCount = 1;
 
             HttpClient httpClient = MinecraftAuth.createHttpClient();
-            StepFullJavaSession.FullJavaSession javaSession =
-                    MinecraftAuth.JAVA_DEVICE_CODE_LOGIN.getFromInput(
-                            httpClient, new StepMsaDeviceCode.MsaDeviceCodeCallback(
-                                    msaDeviceCode -> {
+            JavaAuthManager authManager = JavaAuthManager.create(httpClient)
+                    .login(DeviceCodeMsaAuthService::new, (Consumer<MsaDeviceCode>) msaDeviceCode -> {
                 Log.info("Authorize your Microsoft account on " + msaDeviceCode.getDirectVerificationUri());
                 Log.info("Waiting for authorization.");
-            }));
+            });
 
-            Log.info("Logged in with username: " + javaSession.getMcProfile().getName());
+            MinecraftProfile mcProfile = authManager.getMinecraftProfile().getUpToDate();
+            Log.info("Logged in with username: " + mcProfile.getName());
 
-            GameProfile gameProfile = new GameProfile(javaSession.getMcProfile().getId(), javaSession.getMcProfile().getName());
-            protocol = new MinecraftProtocol(gameProfile, javaSession.getMcProfile().getMcToken().getAccessToken());
+            GameProfile gameProfile = new GameProfile(mcProfile.getId(), mcProfile.getName());
+            protocol = new MinecraftProtocol(gameProfile, authManager.getMinecraftToken().getUpToDate().getToken());
         } else {
             protocol = null;
         }


### PR DESCRIPTION
Updates mc-bots to support Minecraft 1.21.11 (Java Edition, protocol version 774).
## Changes
- MCProtocolLib bumped from 1.21.7-SNAPSHOT to 1.21.11-SNAPSHOT
- MinecraftAuth – migrated to the new API introduced in the latest MinecraftAuth version (pulled in by MCProtocolLib). The old step-based authentication flow (StepFullJavaSession, StepMsaDeviceCode, [MinecraftAuth.JAVA_DEVICE_CODE_LOGIN](vscode-file://vscode-app/c:/Users/erikp/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) was replaced with the new [JavaAuthManager](vscode-file://vscode-app/c:/Users/erikp/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + [DeviceCodeMsaAuthService](vscode-file://vscode-app/c:/Users/erikp/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) pattern.
- Java toolchain updated from 17 to 21